### PR TITLE
feat: add generic SSL/TLS custom CA bundle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Claude Desktop stores these securely in the OS keychain; set them once in the ex
    export USER_GOOGLE_EMAIL=your.email@gmail.com  # Optional: Default email for auth - use this for single user setups and you won't need to set your email in system prompt for magic auth
    export GOOGLE_PSE_API_KEY=your-custom-search-api-key  # Optional: Only needed for Google Custom Search tools
    export GOOGLE_PSE_ENGINE_ID=your-search-engine-id  # Optional: Only needed for Google Custom Search tools
+   export CUSTOM_CA_BUNDLE=/path/to/ca-bundle.pem  # Optional: Custom CA bundle for SSL verification (see SSL_CONFIGURATION.md)
    ```
 
 3. **Server Configuration**:

--- a/SSL_CONFIGURATION.md
+++ b/SSL_CONFIGURATION.md
@@ -1,0 +1,128 @@
+# SSL/TLS Configuration for Custom CA Bundles
+
+This guide explains how to configure the Google Workspace MCP server to work with custom Certificate Authorities (CAs), such as those used by corporate VPNs or security solutions.
+
+## Overview
+
+The Google Workspace MCP server supports using custom CA bundles for SSL/TLS verification. This is useful when:
+- You're behind a corporate firewall/VPN that uses custom certificates
+- You're using security solutions like Cato Networks, Zscaler, or similar
+- You need to add additional trusted CAs beyond system defaults
+
+## Configuration
+
+### 1. Create Your Combined CA Bundle
+
+First, create a combined CA bundle file that includes both system certificates and your custom certificates:
+
+```bash
+# Example: Combine system certs with corporate certs
+cat /etc/ssl/certs/ca-certificates.crt ~/.corporate/custom-ca.pem > ~/combined-ca-bundle.pem
+```
+
+### 2. Configure MCP Server
+
+When adding the Google Workspace MCP server to your MCP client, set the `CUSTOM_CA_BUNDLE` environment variable:
+
+#### Using Claude Desktop
+
+In your Claude Desktop configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "google-workspace": {
+      "command": "uvx",
+      "args": ["workspace-mcp"],
+      "env": {
+        "CUSTOM_CA_BUNDLE": "/Users/yourname/combined-ca-bundle.pem"
+      }
+    }
+  }
+}
+```
+
+#### Using Environment Variables
+
+```bash
+export CUSTOM_CA_BUNDLE=/path/to/your/combined-ca-bundle.pem
+uvx workspace-mcp
+```
+
+#### Using Docker
+
+```bash
+docker run -p 8000:8000 \
+  -e CUSTOM_CA_BUNDLE=/certs/combined-ca-bundle.pem \
+  -v /path/to/your/combined-ca-bundle.pem:/certs/combined-ca-bundle.pem:ro \
+  -v $(pwd):/app \
+  workspace-mcp --transport streamable-http
+```
+
+## How It Works
+
+When `CUSTOM_CA_BUNDLE` is set:
+
+1. The SSL patch module loads early, before any Google API imports
+2. It configures httplib2 to use your custom CA bundle
+3. It sets standard SSL environment variables (`REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, etc.)
+4. All subsequent HTTPS connections will use your custom CA bundle
+
+## Creating CA Bundles for Common Scenarios
+
+### Cato Networks
+```bash
+# Combine system certs with Cato certs
+cat /etc/ssl/cert.pem ~/.cato/*.pem > ~/cato-ca-bundle.pem
+export CUSTOM_CA_BUNDLE=~/cato-ca-bundle.pem
+```
+
+### Zscaler
+```bash
+# Get Zscaler root certificate and combine with system certs
+cat /etc/ssl/certs/ca-certificates.crt ~/Downloads/ZscalerRootCA.pem > ~/zscaler-ca-bundle.pem
+export CUSTOM_CA_BUNDLE=~/zscaler-ca-bundle.pem
+```
+
+### Corporate Proxy
+```bash
+# Combine system certs with corporate CA
+cat /etc/ssl/cert.pem /usr/local/share/ca-certificates/corporate-ca.crt > ~/corporate-ca-bundle.pem
+export CUSTOM_CA_BUNDLE=~/corporate-ca-bundle.pem
+```
+
+## Troubleshooting
+
+### Verify CA Bundle
+```bash
+# Check if your CA bundle is valid
+openssl crl2pkcs7 -nocrl -certfile ~/combined-ca-bundle.pem | openssl pkcs7 -print_certs -noout
+```
+
+### Test SSL Connection
+```python
+# Test script to verify SSL configuration
+import os
+os.environ['CUSTOM_CA_BUNDLE'] = '/path/to/your/combined-ca-bundle.pem'
+
+from auth.ssl_patch import apply_ssl_patch
+apply_ssl_patch()
+
+import httplib2
+http = httplib2.Http()
+resp, content = http.request("https://oauth2.googleapis.com/.well-known/openid-configuration", "GET")
+print(f"Status: {resp.status}")
+```
+
+### Common Issues
+
+1. **Certificate not found**: Ensure the path in `CUSTOM_CA_BUNDLE` is absolute and the file exists
+2. **SSL verification still fails**: Make sure your CA bundle includes all necessary intermediate certificates
+3. **Different behavior between tools**: Some tools may need additional configuration beyond the environment variables
+
+## Security Considerations
+
+- Keep your CA bundle file secure and readable only by your user
+- Regularly update your CA bundle when certificates change
+- Only include CAs that you explicitly trust
+- Consider using separate CA bundles for different environments (dev/prod)

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -9,6 +9,12 @@ import os
 from datetime import datetime
 from typing import List, Optional, Tuple, Dict, Any
 
+# Import SSL patch module early to patch httplib2 before Google APIs use it
+from auth.ssl_patch import apply_ssl_patch
+
+# Apply SSL patch if configured
+apply_ssl_patch()
+
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import Flow
 from google.auth.transport.requests import Request

--- a/auth/ssl_patch.py
+++ b/auth/ssl_patch.py
@@ -1,0 +1,90 @@
+"""SSL certificate patch for custom CA bundle support.
+
+This module provides SSL certificate patching to handle environments where
+custom CA certificates need to be used for proper SSL verification.
+The CA bundle should be created externally and provided via environment variable.
+"""
+
+import os
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def patch_httplib2_with_custom_ca(ca_bundle_path: str) -> bool:
+    """Patch httplib2 to use a custom CA bundle.
+    
+    Args:
+        ca_bundle_path: Path to the custom CA bundle file
+        
+    Returns:
+        bool: True if patch was successful, False otherwise
+    """
+    if not os.path.exists(ca_bundle_path):
+        logger.error(f"CA bundle not found at: {ca_bundle_path}")
+        return False
+    
+    # Method 1: Set environment variables that many libraries respect
+    os.environ['REQUESTS_CA_BUNDLE'] = ca_bundle_path
+    os.environ['CURL_CA_BUNDLE'] = ca_bundle_path
+    os.environ['SSL_CERT_FILE'] = ca_bundle_path
+    logger.info(f"Set SSL certificate environment variables to: {ca_bundle_path}")
+    
+    # Method 2: Patch httplib2 if it's available
+    try:
+        import httplib2
+        
+        # Store the original Http class
+        original_http_class = httplib2.Http
+        
+        class PatchedHttp(original_http_class):
+            """Patched Http class that uses custom CA bundle."""
+            
+            def __init__(self, *args, **kwargs):
+                # Initialize the parent class
+                super().__init__(*args, **kwargs)
+                
+                # Override the ca_certs to use our custom bundle
+                self.ca_certs = ca_bundle_path
+                
+                # Ensure SSL certificate validation is enabled
+                if hasattr(self, 'disable_ssl_certificate_validation'):
+                    self.disable_ssl_certificate_validation = False
+        
+        # Replace the Http class in httplib2
+        httplib2.Http = PatchedHttp
+        logger.info(f"httplib2 patched to use CA bundle: {ca_bundle_path}")
+        return True
+        
+    except ImportError:
+        logger.info("httplib2 not installed, relying on environment variables for SSL configuration")
+        return True
+    except Exception as e:
+        logger.error(f"Failed to patch httplib2: {e}")
+        return False
+
+
+def apply_ssl_patch() -> bool:
+    """Apply SSL patch if configured via environment variable.
+    
+    Looks for CUSTOM_CA_BUNDLE environment variable containing the path
+    to a custom CA bundle file.
+    
+    Returns:
+        bool: True if patch was applied successfully or not needed, False on error
+    """
+    ca_bundle_path = os.environ.get('CUSTOM_CA_BUNDLE')
+    
+    if not ca_bundle_path:
+        logger.debug("CUSTOM_CA_BUNDLE not set, no SSL patching applied")
+        return True
+    
+    logger.info(f"CUSTOM_CA_BUNDLE set to: {ca_bundle_path}")
+    return patch_httplib2_with_custom_ca(ca_bundle_path)
+
+
+# For backward compatibility, check if SSL patching should be applied
+CUSTOM_CA_BUNDLE = os.environ.get('CUSTOM_CA_BUNDLE')
+if CUSTOM_CA_BUNDLE:
+    logger.info(f"Custom CA bundle configured: {CUSTOM_CA_BUNDLE}")

--- a/main.py
+++ b/main.py
@@ -4,6 +4,10 @@ import os
 import sys
 from importlib import metadata
 
+# Import and apply SSL patch early, before any Google API imports
+from auth.ssl_patch import apply_ssl_patch
+apply_ssl_patch()
+
 # Local imports
 from core.server import server, set_transport_mode
 from core.utils import check_credentials_directory_permissions

--- a/test_ssl_patch.py
+++ b/test_ssl_patch.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Test script to verify SSL patch functionality with custom CA bundle."""
+
+import os
+import sys
+import tempfile
+
+# Add the project root to Python path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+print("Testing SSL patch for Google Workspace MCP...")
+print("-" * 60)
+
+# Test 1: Test without CA bundle
+print("\n1. Testing without CUSTOM_CA_BUNDLE...")
+if 'CUSTOM_CA_BUNDLE' in os.environ:
+    del os.environ['CUSTOM_CA_BUNDLE']
+
+from auth.ssl_patch import apply_ssl_patch
+result = apply_ssl_patch()
+print(f"   {'✓' if result else '✗'} SSL patch applied: {result}")
+print("   ℹ  No custom CA bundle configured (expected behavior)")
+
+# Test 2: Test with non-existent CA bundle
+print("\n2. Testing with non-existent CA bundle...")
+os.environ['CUSTOM_CA_BUNDLE'] = '/tmp/non-existent-bundle.pem'
+result = apply_ssl_patch()
+print(f"   {'✓' if not result else '✗'} SSL patch correctly failed for non-existent file")
+
+# Test 3: Test with valid CA bundle
+print("\n3. Testing with valid CA bundle...")
+# Create a temporary CA bundle for testing
+with tempfile.NamedTemporaryFile(mode='w', suffix='.pem', delete=False) as temp_bundle:
+    # Find system certificates
+    system_cert_locations = [
+        '/etc/ssl/certs/ca-certificates.crt',  # Debian/Ubuntu
+        '/etc/pki/tls/certs/ca-bundle.crt',    # RedHat/CentOS
+        '/etc/ssl/cert.pem',                    # macOS/BSD
+        '/System/Library/OpenSSL/certs/cert.pem',  # macOS alternate
+    ]
+    
+    cert_found = False
+    for cert_location in system_cert_locations:
+        if os.path.exists(cert_location):
+            with open(cert_location, 'r') as f:
+                temp_bundle.write(f.read())
+            print(f"   ✓ Created test CA bundle using: {cert_location}")
+            cert_found = True
+            break
+    
+    if not cert_found:
+        print("   ✗ No system certificates found, using dummy certificate")
+        # Write a dummy certificate for testing
+        temp_bundle.write("-----BEGIN CERTIFICATE-----\nDUMMY\n-----END CERTIFICATE-----\n")
+    
+    temp_bundle_path = temp_bundle.name
+
+os.environ['CUSTOM_CA_BUNDLE'] = temp_bundle_path
+result = apply_ssl_patch()
+print(f"   {'✓' if result else '✗'} SSL patch applied with custom CA bundle: {temp_bundle_path}")
+
+# Test 4: Verify httplib2 patching
+print("\n4. Verifying httplib2 patch...")
+try:
+    import httplib2
+    
+    # Create an Http object (should use our patched version)
+    http = httplib2.Http()
+    
+    # Check if ca_certs points to our bundle
+    if hasattr(http, 'ca_certs') and http.ca_certs == temp_bundle_path:
+        print(f"   ✓ httplib2.Http.ca_certs correctly set to: {http.ca_certs}")
+    else:
+        print(f"   ✗ httplib2.Http.ca_certs not set correctly")
+    
+except ImportError:
+    print("   ℹ  httplib2 not installed (test skipped)")
+
+# Test 5: Verify environment variables
+print("\n5. Verifying SSL environment variables...")
+expected_vars = ['REQUESTS_CA_BUNDLE', 'CURL_CA_BUNDLE', 'SSL_CERT_FILE']
+for var in expected_vars:
+    value = os.environ.get(var)
+    if value == temp_bundle_path:
+        print(f"   ✓ {var} = {value}")
+    else:
+        print(f"   ✗ {var} not set correctly (got: {value})")
+
+# Test 6: Test actual HTTPS connection (if system certs were found)
+if cert_found:
+    print("\n6. Testing HTTPS connection to Google OAuth2...")
+    try:
+        import httplib2
+        
+        # Create an Http object (should use our patched version)
+        http = httplib2.Http()
+        
+        # Try to connect to Google OAuth2 endpoint
+        resp, content = http.request("https://oauth2.googleapis.com/.well-known/openid-configuration", "GET")
+        
+        print(f"   ✓ Successfully connected to oauth2.googleapis.com")
+        print(f"   ✓ Response status: {resp.status}")
+        print(f"   ✓ Response length: {len(content)} bytes")
+        
+    except Exception as e:
+        print(f"   ✗ Failed to connect: {e}")
+else:
+    print("\n6. Skipping HTTPS test (no valid system certificates found)")
+
+# Test 7: Test Google API client imports
+print("\n7. Testing Google API client imports...")
+try:
+    from google.oauth2.credentials import Credentials
+    from googleapiclient.discovery import build
+    from google.auth.transport.requests import Request
+    print("   ✓ Google API client imports successful")
+except Exception as e:
+    print(f"   ✗ Failed to import Google API clients: {e}")
+
+# Cleanup
+print("\n8. Cleanup...")
+try:
+    os.unlink(temp_bundle_path)
+    print(f"   ✓ Cleaned up temporary CA bundle: {temp_bundle_path}")
+except Exception as e:
+    print(f"   ✗ Failed to cleanup: {e}")
+
+print("\n" + "=" * 60)
+print("Test completed!")
+print("\nTo use with your own CA bundle:")
+print(f"  export CUSTOM_CA_BUNDLE=/path/to/your/ca-bundle.pem")
+print(f"  uvx workspace-mcp")


### PR DESCRIPTION
## Summary

This PR refactors the SSL certificate patching feature to be more generic and configurable, allowing the MCP server to work with any corporate VPN/proxy that requires custom CA certificates.

## Changes

### Refactored SSL Patch Module (`auth/ssl_patch.py`)
- Removed Cato-specific certificate discovery logic
- Now accepts external CA bundle path via `CUSTOM_CA_BUNDLE` environment variable
- Simplified API with single `apply_ssl_patch()` function
- Maintains httplib2 patching capability for Google API compatibility

### Configuration
- Users provide their own combined CA bundle (system + custom certificates)
- Configure via environment variable when adding MCP server:
  ```json
  {
    "mcpServers": {
      "google-workspace": {
        "command": "uvx",
        "args": ["workspace-mcp"],
        "env": {
          "CUSTOM_CA_BUNDLE": "/path/to/combined-ca-bundle.pem"
        }
      }
    }
  }
  ```

### Documentation
- Added comprehensive `SSL_CONFIGURATION.md` with:
  - Setup instructions for various scenarios (Cato, Zscaler, corporate proxies)
  - Examples of creating combined CA bundles
  - Troubleshooting guide
- Updated README.md with SSL configuration reference

### Testing
- Updated test suite (`test_ssl_patch.py`) for new implementation
- Tests verify CA bundle loading, httplib2 patching, and environment variable setup

## Benefits

- **Generic Solution**: Works with any VPN/proxy requiring custom CAs
- **User Control**: CA bundle creation is external, giving users full control
- **Simplified Code**: Removed certificate discovery complexity
- **Better Security**: Users explicitly manage their trusted CAs

## Migration

For existing users of the Cato-specific patch:
1. Create a combined CA bundle: `cat /etc/ssl/cert.pem ~/.cato/*.pem > ~/ca-bundle.pem`
2. Set environment variable: `export CUSTOM_CA_BUNDLE=~/ca-bundle.pem`

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>